### PR TITLE
fix: use venv python directly to avoid uv cache permission error

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -15,4 +15,4 @@ Running as user/group: $(id container-user)
 "
 
 # Start the app as container-user, -u for unbuffed print output
-su -c "uv run python -u /app/src/sonarr_putio_helper.py" container-user
+su -c "/app/.venv/bin/python -u /app/src/sonarr_putio_helper.py" container-user


### PR DESCRIPTION
container-user is created without a home directory (-H flag), so uv
cannot initialise its cache at /home/container-user/.cache/uv, causing
an immediate crash on startup. The dependencies are already installed
into /app/.venv at image build time, so invoking uv at runtime is
unnecessary. Switch to the venv interpreter directly to skip uv's cache
lookup entirely.

https://claude.ai/code/session_01U8ka6PNoibRiUCQ9TMhPja